### PR TITLE
Add banner pointing to force-color.org

### DIFF
--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -123,6 +123,22 @@ blockquote {
 
 
 /**
+ * Banner
+ */
+blockquote.banner {
+    color: $text-color;
+    background-color: #ffffdd;
+    border-left: 4px solid #e8c600;
+    padding: $spacing-unit / 2;
+    font-style: normal;
+    letter-spacing: 0;
+    font-size: $base-font-size;
+    margin-bottom: $spacing-unit;
+}
+
+
+
+/**
  * Code formatting
  */
 pre,

--- a/index.md
+++ b/index.md
@@ -3,6 +3,11 @@ layout: default
 title:  Standard for ANSI Colors in Terminals
 ---
 
+{: .banner}
+> **Note:** For new applications, we recommend using `FORCE_COLOR` instead of
+> `CLICOLOR_FORCE`. See [force-color.org](https://force-color.org) for details.
+> This site remains as documentation for existing users.
+
 # {{ page.title }}
 
 The current situation to get colored output from most console commands is a


### PR DESCRIPTION
Fixes https://github.com/jhasse/clicolors/issues/15.

As suggested at https://github.com/jhasse/clicolors/issues/15#issuecomment-4132437919, adds a banner pointing to the `FORCE_COLOR` site.

<img width="819" height="274" alt="image" src="https://github.com/user-attachments/assets/9704c6f1-efd2-4307-850f-bdea1467f0b0" />

Demo: https://hugovk.dev/clicolors/