### PR TITLE
resolve #29: compatibility with `FORCE_COLOR` standard

### DIFF
--- a/index.md
+++ b/index.md
@@ -4,9 +4,12 @@ title:  Standard for ANSI Colors in Terminals
 ---
 
 {: .banner}
-> **Note:** For new applications, we recommend using `FORCE_COLOR` instead of
-> `CLICOLOR_FORCE`. See [force-color.org](https://force-color.org) for details.
-> This site remains as documentation for existing users.
+> **Note:** This standard is deprecated. For new applications, we recommend
+> using [the force-color](https://force-color.org/) and
+> [no-color](https://web.archive.org/web/20260616201813/https://no-color.org/)
+> standards instead of this standard. Software that already supports this
+> standard should treat `FORCE_COLOR` as an alias for `CLICOLOR_FORCE`,
+> enabling color whenever either is set, unless `NO_COLOR` is also set.
 
 # {{ page.title }}
 


### PR DESCRIPTION
Also replaces the "remains as documentation" sentence with an explicit "deprecation" sentence.

The link to the `no-color` site is a Wayback link rather than a direct link because the site has been down for a while now, and I don't know if or when it will return.

Unfortunately, this is currently the *only* standard of the three that actually tries to address variable precedence. There's [an RFC in `FORCE_COLOR`](https://github.com/donatj/force-color.org/pull/80) that may make the precedence rules explicit, or may just punt and say that precedence is undefined; but as written, both the RFC and the example implementation in the `FORCE_COLOR` standard itself currently have the opposite precedence from this standard: `FORCE_COLOR` overrides `NO_COLOR`. I considered adding a separate banner mentioning that problem, but since the banner now links to both standards, I decided that it's sufficient for the sentence about compatibility with *this* standard to reiterate the existing precedence rule in this standard.